### PR TITLE
integrate new galter-subjects-utils

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,6 +16,6 @@ recursive-include .github/workflows *.yml
 
 # added by check-manifest
 include *.md
-recursive-include invenio_subjects_lcsh *.jsonl
+recursive-include invenio_subjects_lcsh *.csv
 recursive-include invenio_subjects_lcsh *.yaml *.yml
 recursive-include tests *.py

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Install this extension to get [Library of Congress Subject Headings](https://id.loc.gov/authorities/subjects.html) into your instance.
 
+Note that this list excludes `-781` geographical variations as it's not their original intent to be independent tagging terms.
+
 ## Installation
 
 From your instance directory:
@@ -16,54 +18,64 @@ This will add it to your Pipfile.
 
 ## Versions
 
-This repository follows [calendar versioning](https://calver.org/) for year and month:
+This repository follows [calendar versioning](https://calver.org/) for year and month. It does a "best effort" attempt at tracking the LCSH updates in an *up-to-and-including* version date manner. The following are illustrative cases of how to understand the versioning of this distribution package:
+
+| Last LCSH update included | version of this project | date of release of this project |
+| ------------------------- | ----------------------- | ------------------------------- |
+| 2024-01-31                | 2024.1.X                | any time after 2024-01-31       |
+| 2023-12-31                | 2023.12.X               | any time after 2023-12-31       |
+
 
 `2021.06.18` is both a valid semantic version and an indicator of the year-month corresponding to the loaded terms.
 `18` here is a patch number (not a day).
 
-So far the package is compatible with InvenioRDM 9.1+'s subjects "ABI". If there is a breaking change, a compatibility
-table will be provided to indicate which version is compatible with with InvenioRDM's "ABI".
 
 ## Usage
 
 There are 2 types of users for this package. Maintainers of the package and instance administrators.
 
-### Instance administrators
+### Update terms in an instance
 
 For instance administrators, after you have installed the extension as per the steps above, you will want to reload your instance's fixtures: `pipenv run invenio rdm-records fixtures`. This will install the new terms in your instance.
 
-Updating existing terms currently requires manual replacement.
-
-### Maintainers
-
-This package should probably be updated on a yearly basis. Here we show how.
-
-0. Install this package locally with the `dev` extra:
+Alternatively, or if you want to update your already loaded subjects to a new listing (e.g. from one year's list to another), you can update your instance's LCSH subjects as per below. Updating subjects this way takes care of everything for you: the subjects themselves and the records/drafts using those subjects. **WARNING** This operation can _remove_ subjects.
 
 ```bash
-pipenv run pip install -e .[dev]
+# In your instance's project
+# Download up-to-date listings
+pipenv run invenio galter_subjects lcsh download -d /path/to/downloads/storage/
+# Generate file containg deltas to transition your instance to the downloaded listing
+pipenv run invenio galter_subjects lcsh deltas -d /path/to/downloads/storage/ -o /path/to/deltas_lcsh.csv
+# Update your instance - *this operation will modify your instance*
+pipenv run invenio galter_subjects update /path/to/deltas_lcsh.csv
 ```
 
-1. Use the installed `galter-subjects-utils` tool to get the new list:
+Look at the help text for these commands to see additional options that can be passed.
+In particular, options for `galter_subjects update` allow you to store renamed, replaced or removed subjects on records according to a template of your choice.
+
+### Maintain the initial vocabulary list
+
+When a new list of LCSH terms comes out, this package should be updated to provide an up-to-date starting fixture. Here we show how.
+
+**Pre-requisite/Context**
+
+Maintaining the vocabulary file doesn't apriori need any Inveniordm functionality, but updating an instance does and
+as such this project depends on `invenio-app-rdm`. In turn, because of the plugin system of InvenioRDM, this dependency requires
+`invenio-search[X]` (where X is `elasticsearch7` or `opensearch1` or `opensearch2`) to be installed. It has to be installed separately because this project makes no assumption about the document engine used by the instance. So, even for maintainers of this project, `invenio-search` with an appropriate extra (we choose `elasticsearch2` but it is inconsequential) needs to be installed separately to update the vocabulary file.
+
+**Commands**
+
+Once you have that dependency installed, you can run the following commands:
 
 ```bash
-pipenv run galter-subjects-utils lcsh --output-file invenio_subjects_lcsh/vocabularies/subjects_lcsh.jsonl
+# In this project
+# Download up-to-date listings
+pipenv run invenio galter_subjects lcsh download -d /path/to/downloads/storage/
+# Generate file containing initial listing
+pipenv run invenio galter_subjects lcsh file -d /path/to/downloads/storage/ -o invenio_subjects_lcsh/vocabularies/subjects_lcsh.csv
 ```
 
-   This will
-
-   1. Download the new list(s)
-   2. Read it filtering for topics
-   3. Convert terms to InvenioRDM subjects format
-   4. Write those to the specified file
-
-2. Check the manifest (it should typically be all good)
-
-```bash
-pipenv run inv check-manifest
-```
-
-3. When you are happy with the list, bump the version and release it.
+When you are happy with the list, bump the version in `pyproject.toml` and release it.
 
 ## Development
 

--- a/invenio_subjects_lcsh/__init__.py
+++ b/invenio_subjects_lcsh/__init__.py
@@ -7,6 +7,3 @@
 # details.
 
 """LCSH subject terms for InvenioRDM."""
-
-
-__version__ = '2023.11.2'

--- a/invenio_subjects_lcsh/vocabularies/vocabularies.yaml
+++ b/invenio_subjects_lcsh/vocabularies/vocabularies.yaml
@@ -2,6 +2,6 @@ subjects:
   pid-type: sub
   schemes:
     - id: LCSH
-      data-file: subjects_lcsh.jsonl
+      data-file: subjects_lcsh.csv
       name: Library of Congress Subject Headings
       uri: "https://id.loc.gov/authorities/subjects.html"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,30 +17,26 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11"
+    "Programming Language :: Python :: 3.10"
 ]
-dependencies = []
+dependencies = [
+    "galter-subjects-utils>=0.4.1,<2.0",
+]
 description = "LCSH subject terms for InvenioRDM"
-dynamic = ["version"]
 keywords = ["invenio", "inveniordm", "subjects", "LCSH"]
 license = {file = "LICENSE"}
 name = "invenio-subjects-lcsh"
 readme = "README.md"
 requires-python = ">=3.8"
 urls = {Repository = "https://github.com/galterlibrary/invenio-subjects-lcsh"}
+version = "2024.1.0"
 
 [project.optional-dependencies]
 dev = [
     "check-manifest>=0.49",
     "invoke>=2.2,<3.0",
-    "galter-subjects-utils>=0.2.0,<2.0",
     "pyyaml>=5.4.1",
-    "pytest>=7.2.0",
-    "pytest-cov>=3.0.0",
-    "pytest-isort>=3.0.0",
-    "pytest-pycodestyle>=2.2.0",
-    "pytest-pydocstyle>=2.2.3"
+    "pytest-invenio>=2.1.1,<3.0.0",
 ]
 
 [project.entry-points."invenio_rdm_records.fixtures"]
@@ -48,9 +44,6 @@ invenio_subjects_lcsh = "invenio_subjects_lcsh.vocabularies"
 
 [tool.setuptools]
 packages = ["invenio_subjects_lcsh", "invenio_subjects_lcsh.vocabularies"]
-
-[tool.setuptools.dynamic]
-version = {attr = "invenio_subjects_lcsh.__version__"}
 
 [tool.check-manifest]
 ignore = [

--- a/tests/test_invenio_subjects_lcsh.py
+++ b/tests/test_invenio_subjects_lcsh.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021 Northwestern University.
+# Copyright (C) 2021-2024 Northwestern University.
 #
 # invenio-subjects-lcsh is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -12,13 +12,6 @@ from pathlib import Path
 
 import pkg_resources
 import yaml
-
-from invenio_subjects_lcsh import __version__
-
-
-def test_version():
-    """Test version import."""
-    assert __version__
 
 
 def test_vocabularies_yaml():


### PR DESCRIPTION
- depends on https://github.com/galterlibrary/galter-subjects-utils/pull/39 being merged and released
- **use new version of galter-subjects-utils**
- **release: v2024.1.0**
