### PR TITLE
:package: release v2025.1.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ name = "invenio-subjects-lcsh"
 readme = "README.md"
 requires-python = ">=3.9"
 urls = {Repository = "https://github.com/galterlibrary/invenio-subjects-lcsh"}
-version = "2024.1.1"
+version = "2025.1.17"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
This is just updating the initial LCSH list of subjects up-to-including 2025.1.17