### PR TITLE
tests: extend support to Python 3.14

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,35 +18,5 @@ on:
         default: 'Manual trigger'
 
 jobs:
-  Tests:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-          python-version: ["3.9", "3.11", "3.12", "3.13"]
-          requirements-level: [pypi]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install build dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools wheel build
-
-      - name: Install dependencies
-        run: |
-          pip install .[dev]
-          pip freeze
-
-      - name: Check manifest
-        run: |
-          invoke check-manifest
-
-      - name: Run tests
-        run: |
-          invoke test --no-color
+  tests:
+    uses: galterlibrary/reusable-workflows/.github/workflows/inveniordm-tests-python.yml@main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ authors = [
 classifiers = [
     "Environment :: Web Environment",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
@@ -25,7 +24,7 @@ dependencies = [
 ]
 description = "LCSH subject terms for InvenioRDM"
 keywords = ["invenio", "inveniordm", "subjects", "LCSH"]
-license = {file = "LICENSE"}
+license = "MIT"
 name = "invenio-subjects-lcsh"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
This is using the feature branch of https://github.com/galterlibrary/reusable-workflows/pull/2 to test and illustrate. The main branch will be used when the other one is merged.